### PR TITLE
[FIXED]: fixed JSON pasing error on instagram html response.

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,20 +33,24 @@ InstagramClient.prototype.fetch = function (path, params, callback) {
 	    raw += chunk;
 	});
 	res.on('end', function () {
-	    var response = JSON.parse(raw);
+        try{
+            var response = JSON.parse(raw);
 
-	    var pagination = null;
-	    if (typeof(response['pagination']) != 'undefined') {
-		pagination = response['pagination'];
-	    }
+            var pagination = null;
+            if (typeof(response['pagination']) != 'undefined') {
+                pagination = response['pagination'];
+            }
 
-	    if (response['meta']['code'] == 200) {
-		callback(response['data'], 
-			 null, 
-			 pagination);
-	    }else{
-		callback(response['meta'], response['meta']['code'], pagination);
-	    }
+            if (response['meta']['code'] == 200) {
+                callback(response['data'], 
+                    null, 
+                    pagination);
+            }else{
+                callback(response['meta'], response['meta']['code'], pagination);
+            }
+        } catch (e) {
+            callback({}, {}, {});
+        }
 	});
     });    
 }


### PR DESCRIPTION
Sometimes it happens when the search tag is like ';bpym'. This case instagram.tags.media function breaks. The reason is the response of Instagram. It sends back not json code, but html.
